### PR TITLE
Add environments prefix to multi-workspace attributes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     default: ''
   environments_variables:
     required: false
-    description: A YAML encoded map of environment names to a list of Terrafrom Cloud variable objects
+    description: A YAML encoded map of environment names to a list of Terraform Cloud variable objects
     default: ''
 outputs:
   workspaces:

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -11,7 +11,7 @@ func Run(inputs Inputs, out Outputter) error {
 		return err
 	}
 
-	merged := MergeConfigs(config, NewDefaults(config.Names))
+	merged := MergeConfigs(config, NewDefaults(config.Environments))
 
 	if err := merged.SetOutputs(out); err != nil {
 		return err

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -45,9 +45,9 @@ func TestRun(t *testing.T) {
 		{
 			message: "empty string inputs",
 			input: Inputs{
-				Environments: "",
-				Tags:         "",
-				Variables:    "",
+				Environments:          "",
+				EnvironmentsTags:      "",
+				EnvironmentsVariables: "",
 			},
 			expected: testCaseRunExpected{
 				outputs: map[string]string{
@@ -61,9 +61,9 @@ func TestRun(t *testing.T) {
 		{
 			message: "empty yaml inputs",
 			input: Inputs{
-				Environments: "",
-				Tags:         "",
-				Variables:    "",
+				Environments:          "",
+				EnvironmentsTags:      "",
+				EnvironmentsVariables: "",
 			},
 			expected: testCaseRunExpected{
 				outputs: map[string]string{
@@ -80,7 +80,7 @@ func TestRun(t *testing.T) {
 				Environments: `---
 - staging
 - production`,
-				Variables: `---
+				EnvironmentsVariables: `---
 staging:
 - key: secret
   value: masked				
@@ -113,7 +113,7 @@ staging:
 				Environments: `---
 - staging
 - production`,
-				Variables: `---
+				EnvironmentsVariables: `---
 staging:
 - key: environment
   value: bar

--- a/internal/action/config.go
+++ b/internal/action/config.go
@@ -12,17 +12,17 @@ var (
 
 // Config holds the parsed workspace values
 type Config struct {
-	Variables map[string][]Variable
-	Tags      map[string][]string
-	Names     []string
+	EnvironmentsVariables map[string][]Variable
+	EnvironmentsTags      map[string][]string
+	Environments          []string
 }
 
 // NewConfig returns an empty Config struct
 func NewConfig() Config {
 	return Config{
-		Names:     []string{},
-		Variables: map[string][]Variable{},
-		Tags:      map[string][]string{},
+		Environments:          []string{},
+		EnvironmentsVariables: map[string][]Variable{},
+		EnvironmentsTags:      map[string][]string{},
 	}
 }
 
@@ -31,55 +31,55 @@ func MergeConfigs(a Config, b Config) Config {
 	merged := NewConfig()
 
 	envMap := map[string]bool{}
-	for _, e := range append(a.Names, b.Names...) {
+	for _, e := range append(a.Environments, b.Environments...) {
 		if _, ok := envMap[e]; !ok {
-			merged.Names = append(merged.Names, e)
+			merged.Environments = append(merged.Environments, e)
 			envMap[e] = true
 		}
 	}
 
-	for _, e := range merged.Names {
-		merged.Tags[e] = []string{}
+	for _, e := range merged.Environments {
+		merged.EnvironmentsTags[e] = []string{}
 
 		tagMap := map[string]bool{}
 
-		if aTags, ok := a.Tags[e]; ok {
+		if aTags, ok := a.EnvironmentsTags[e]; ok {
 			for _, t := range aTags {
 				if _, ok := tagMap[t]; !ok {
-					merged.Tags[e] = append(merged.Tags[e], t)
+					merged.EnvironmentsTags[e] = append(merged.EnvironmentsTags[e], t)
 					tagMap[t] = true
 				}
 			}
 		}
 
-		if bTags, ok := b.Tags[e]; ok {
+		if bTags, ok := b.EnvironmentsTags[e]; ok {
 			for _, t := range bTags {
 				if _, ok := tagMap[t]; !ok {
-					merged.Tags[e] = append(merged.Tags[e], t)
+					merged.EnvironmentsTags[e] = append(merged.EnvironmentsTags[e], t)
 					tagMap[t] = true
 				}
 			}
 		}
 	}
 
-	for _, e := range merged.Names {
-		merged.Variables[e] = []Variable{}
+	for _, e := range merged.Environments {
+		merged.EnvironmentsVariables[e] = []Variable{}
 
 		varMap := map[string]Variable{}
 
-		if aVars, ok := a.Variables[e]; ok {
+		if aVars, ok := a.EnvironmentsVariables[e]; ok {
 			for _, v := range aVars {
 				if _, ok := varMap[fmt.Sprintf("%s-%s", v.Key, v.Category)]; !ok {
-					merged.Variables[e] = append(merged.Variables[e], v)
+					merged.EnvironmentsVariables[e] = append(merged.EnvironmentsVariables[e], v)
 					varMap[fmt.Sprintf("%s-%s", v.Key, v.Category)] = v
 				}
 			}
 		}
 
-		if bVars, ok := b.Variables[e]; ok {
+		if bVars, ok := b.EnvironmentsVariables[e]; ok {
 			for _, v := range bVars {
 				if _, ok := varMap[fmt.Sprintf("%s-%s", v.Key, v.Category)]; !ok {
-					merged.Variables[e] = append(merged.Variables[e], v)
+					merged.EnvironmentsVariables[e] = append(merged.EnvironmentsVariables[e], v)
 					varMap[fmt.Sprintf("%s-%s", v.Key, v.Category)] = v
 				}
 			}

--- a/internal/action/config_test.go
+++ b/internal/action/config_test.go
@@ -17,49 +17,49 @@ func TestMergeConfig(t *testing.T) {
 		{
 			message: "no tags",
 			input: [2]Config{
-				{Names: []string{"staging"}},
+				{Environments: []string{"staging"}},
 				{},
 			},
 			expected: Config{
-				Names:     []string{"staging"},
-				Tags:      map[string][]string{"staging": {}},
-				Variables: map[string][]Variable{"staging": {}},
+				Environments:          []string{"staging"},
+				EnvironmentsTags:      map[string][]string{"staging": {}},
+				EnvironmentsVariables: map[string][]Variable{"staging": {}},
 			},
 		},
 		{
 			message: "dedupe workspace tags",
 			input: [2]Config{
 				{
-					Names: []string{"staging"},
-					Tags:  map[string][]string{"staging": {"environment:staging"}},
+					Environments:     []string{"staging"},
+					EnvironmentsTags: map[string][]string{"staging": {"environment:staging"}},
 				},
-				{Tags: map[string][]string{"staging": {"environment:staging"}}},
+				{EnvironmentsTags: map[string][]string{"staging": {"environment:staging"}}},
 			},
 			expected: Config{
-				Names:     []string{"staging"},
-				Tags:      map[string][]string{"staging": {"environment:staging"}},
-				Variables: map[string][]Variable{"staging": {}},
+				Environments:          []string{"staging"},
+				EnvironmentsTags:      map[string][]string{"staging": {"environment:staging"}},
+				EnvironmentsVariables: map[string][]Variable{"staging": {}},
 			},
 		},
 		{
 			message: "dedupe variables",
 			input: [2]Config{
 				{
-					Names: []string{"staging"},
-					Variables: map[string][]Variable{
+					Environments: []string{"staging"},
+					EnvironmentsVariables: map[string][]Variable{
 						"staging": {{Key: "environment", Value: "staging", Category: "terraform"}},
 					},
 				},
 				{
-					Variables: map[string][]Variable{
+					EnvironmentsVariables: map[string][]Variable{
 						"staging": {{Key: "environment", Value: "staging", Category: "terraform"}},
 					},
 				},
 			},
 			expected: Config{
-				Names: []string{"staging"},
-				Tags:  map[string][]string{"staging": {}},
-				Variables: map[string][]Variable{
+				Environments:     []string{"staging"},
+				EnvironmentsTags: map[string][]string{"staging": {}},
+				EnvironmentsVariables: map[string][]Variable{
 					"staging": {{Key: "environment", Value: "staging", Category: "terraform"}},
 				},
 			},
@@ -68,8 +68,8 @@ func TestMergeConfig(t *testing.T) {
 			message: "extend default",
 			input: [2]Config{
 				{
-					Names: []string{"staging", "production"},
-					Variables: map[string][]Variable{
+					Environments: []string{"staging", "production"},
+					EnvironmentsVariables: map[string][]Variable{
 						"staging": {
 							{Key: "environment", Value: "staging", Category: "terraform"},
 						},
@@ -77,14 +77,14 @@ func TestMergeConfig(t *testing.T) {
 							{Key: "environment", Value: "production", Category: "terraform"},
 						},
 					},
-					Tags: map[string][]string{
+					EnvironmentsTags: map[string][]string{
 						"staging":    {"environment:staging"},
 						"production": {"environment:production"},
 					},
 				},
 				{
-					Names: []string{"staging", "production"},
-					Variables: map[string][]Variable{
+					Environments: []string{"staging", "production"},
+					EnvironmentsVariables: map[string][]Variable{
 						"staging": {
 							{Key: "environment", Value: "staging", Category: "terraform"},
 							{Key: "foo", Value: "bar", Category: "env"},
@@ -93,15 +93,15 @@ func TestMergeConfig(t *testing.T) {
 							{Key: "baz", Value: "woz", Category: "terraform"},
 						},
 					},
-					Tags: map[string][]string{
+					EnvironmentsTags: map[string][]string{
 						"staging":    {"foo:bar"},
 						"production": {"environment:production", "baz:woz"},
 					},
 				},
 			},
 			expected: Config{
-				Names: []string{"staging", "production"},
-				Variables: map[string][]Variable{
+				Environments: []string{"staging", "production"},
+				EnvironmentsVariables: map[string][]Variable{
 					"staging": {
 						{Key: "environment", Value: "staging", Category: "terraform"},
 						{Key: "foo", Value: "bar", Category: "env"},
@@ -111,7 +111,7 @@ func TestMergeConfig(t *testing.T) {
 						{Key: "baz", Value: "woz", Category: "terraform"},
 					},
 				},
-				Tags: map[string][]string{
+				EnvironmentsTags: map[string][]string{
 					"staging":    {"environment:staging", "foo:bar"},
 					"production": {"environment:production", "baz:woz"},
 				},
@@ -126,11 +126,11 @@ func TestMergeConfig(t *testing.T) {
 			t.Parallel()
 
 			actual := MergeConfigs(tc.input[0], tc.input[1])
-			assert.ElementsMatch(t, tc.expected.Names, actual.Names)
+			assert.ElementsMatch(t, tc.expected.Environments, actual.Environments)
 
-			for _, e := range actual.Names {
-				assert.ElementsMatch(t, tc.expected.Tags[e], actual.Tags[e])
-				assert.ElementsMatch(t, tc.expected.Variables[e], actual.Variables[e])
+			for _, e := range actual.Environments {
+				assert.ElementsMatch(t, tc.expected.EnvironmentsTags[e], actual.EnvironmentsTags[e])
+				assert.ElementsMatch(t, tc.expected.EnvironmentsVariables[e], actual.EnvironmentsVariables[e])
 			}
 		})
 	}

--- a/internal/action/defaults.go
+++ b/internal/action/defaults.go
@@ -4,15 +4,15 @@ import "fmt"
 
 func NewDefaults(environments []string) Config {
 	defaults := Config{
-		Names:     []string{},
-		Variables: map[string][]Variable{},
-		Tags:      map[string][]string{},
+		Environments:          []string{},
+		EnvironmentsVariables: map[string][]Variable{},
+		EnvironmentsTags:      map[string][]string{},
 	}
 
 	for _, e := range environments {
-		defaults.Names = append(defaults.Names, e)
-		defaults.Tags[e] = []string{fmt.Sprintf("environment:%s", e)}
-		defaults.Variables[e] = []Variable{{Key: "environment", Value: e, Category: "terraform"}}
+		defaults.Environments = append(defaults.Environments, e)
+		defaults.EnvironmentsTags[e] = []string{fmt.Sprintf("environment:%s", e)}
+		defaults.EnvironmentsVariables[e] = []Variable{{Key: "environment", Value: e, Category: "terraform"}}
 	}
 
 	return defaults

--- a/internal/action/defaults_test.go
+++ b/internal/action/defaults_test.go
@@ -23,12 +23,12 @@ func TestNewDefaults(t *testing.T) {
 			message: "environments",
 			input:   NewDefaults([]string{"staging", "production"}),
 			expected: Config{
-				Names: []string{"staging", "production"},
-				Tags: map[string][]string{
+				Environments: []string{"staging", "production"},
+				EnvironmentsTags: map[string][]string{
 					"staging":    {"environment:staging"},
 					"production": {"environment:production"},
 				},
-				Variables: map[string][]Variable{
+				EnvironmentsVariables: map[string][]Variable{
 					"staging":    {{Key: "environment", Value: "staging", Category: "terraform"}},
 					"production": {{Key: "environment", Value: "production", Category: "terraform"}},
 				},

--- a/internal/action/inputs.go
+++ b/internal/action/inputs.go
@@ -7,9 +7,9 @@ import (
 )
 
 type Inputs struct {
-	Environments string
-	Tags         string
-	Variables    string
+	Environments          string
+	EnvironmentsTags      string
+	EnvironmentsVariables string
 }
 
 func (i Inputs) Parse() (Config, error) {
@@ -19,7 +19,7 @@ func (i Inputs) Parse() (Config, error) {
 	}
 
 	var wsVars map[string][]Variable
-	if err := yaml.Unmarshal([]byte(i.Variables), &wsVars); err != nil {
+	if err := yaml.Unmarshal([]byte(i.EnvironmentsVariables), &wsVars); err != nil {
 		return Config{}, fmt.Errorf("failed to parse workspace variables: %w", err)
 	}
 
@@ -36,7 +36,7 @@ func (i Inputs) Parse() (Config, error) {
 	}
 
 	var wsTags map[string][]string
-	if err := yaml.Unmarshal([]byte(i.Tags), &wsTags); err != nil {
+	if err := yaml.Unmarshal([]byte(i.EnvironmentsTags), &wsTags); err != nil {
 		return Config{}, fmt.Errorf("failed to parse workspace tags: %w", err)
 	}
 
@@ -53,8 +53,8 @@ func (i Inputs) Parse() (Config, error) {
 	}
 
 	return Config{
-		Names:     environments,
-		Variables: wsVars,
-		Tags:      wsTags,
+		Environments:          environments,
+		EnvironmentsVariables: wsVars,
+		EnvironmentsTags:      wsTags,
 	}, nil
 }

--- a/internal/action/inputs_test.go
+++ b/internal/action/inputs_test.go
@@ -29,13 +29,13 @@ func TestInputsParse(t *testing.T) {
 - production`,
 			},
 			expected: Config{
-				Names: []string{"staging", "production"},
+				Environments: []string{"staging", "production"},
 			},
 		},
 		{
 			message: "basic workspace tags",
 			input: Inputs{
-				Tags: `---
+				EnvironmentsTags: `---
 staging:
   - foo:bar
 production:
@@ -45,8 +45,8 @@ production:
   - production`,
 			},
 			expected: Config{
-				Names: []string{"staging", "production"},
-				Tags: map[string][]string{
+				Environments: []string{"staging", "production"},
+				EnvironmentsTags: map[string][]string{
 					"staging":    {"foo:bar"},
 					"production": {"baz:woz"},
 				},
@@ -58,13 +58,13 @@ production:
 				Environments: `---
   - staging
   - production`,
-				Tags: `---
+				EnvironmentsTags: `---
 staging:
   - foo:bar`,
 			},
 			expected: Config{
-				Names: []string{"staging", "production"},
-				Tags: map[string][]string{
+				Environments: []string{"staging", "production"},
+				EnvironmentsTags: map[string][]string{
 					"staging": {"foo:bar"},
 				},
 			},
@@ -74,7 +74,7 @@ staging:
 			input: Inputs{
 				Environments: `---
 - production`,
-				Tags: `---
+				EnvironmentsTags: `---
 staging:
   - foo:bar`,
 			},
@@ -86,7 +86,7 @@ staging:
 				Environments: `---
 - staging
 - production`,
-				Variables: `---
+				EnvironmentsVariables: `---
 staging:
 - key: foo
   value: bar
@@ -97,8 +97,8 @@ production:
   category: terraform`,
 			},
 			expected: Config{
-				Names: []string{"staging", "production"},
-				Variables: map[string][]Variable{
+				Environments: []string{"staging", "production"},
+				EnvironmentsVariables: map[string][]Variable{
 					"staging":    {{Key: "foo", Value: "bar", Category: "terraform"}},
 					"production": {{Key: "baz", Value: "woz", Category: "terraform"}},
 				},
@@ -110,15 +110,15 @@ production:
 				Environments: `---
 - staging
 - production`,
-				Variables: `---
+				EnvironmentsVariables: `---
 staging:
 - key: foo
   value: bar
   category: terraform`,
 			},
 			expected: Config{
-				Names: []string{"staging", "production"},
-				Variables: map[string][]Variable{
+				Environments: []string{"staging", "production"},
+				EnvironmentsVariables: map[string][]Variable{
 					"staging": {{Key: "foo", Value: "bar", Category: "terraform"}},
 				},
 			},
@@ -128,7 +128,7 @@ staging:
 			input: Inputs{
 				Environments: `---
 - production`,
-				Variables: `---
+				EnvironmentsVariables: `---
 staging:
 - key: foo
   value: bar

--- a/internal/action/outputs.go
+++ b/internal/action/outputs.go
@@ -5,22 +5,16 @@ import (
 	"fmt"
 )
 
-type Outputs struct {
-	Workspaces string
-	Tags       string
-	Variables  string
-}
-
 func (c Config) SetOutputs(o Outputter) error {
-	if err := setOutput(o, "workspaces", c.Names); err != nil {
+	if err := setOutput(o, "workspaces", c.Environments); err != nil {
 		return err
 	}
 
-	if err := setOutput(o, "workspace_tags", c.Tags); err != nil {
+	if err := setOutput(o, "workspace_tags", c.EnvironmentsTags); err != nil {
 		return err
 	}
 
-	for _, vars := range c.Variables {
+	for _, vars := range c.EnvironmentsVariables {
 		for _, v := range vars {
 			if v.Sensitive {
 				o.AddMask(v.Value)
@@ -28,7 +22,7 @@ func (c Config) SetOutputs(o Outputter) error {
 		}
 	}
 
-	if err := setOutput(o, "workspace_variables", c.Variables); err != nil {
+	if err := setOutput(o, "workspace_variables", c.EnvironmentsVariables); err != nil {
 		return err
 	}
 

--- a/internal/action/outputs_test.go
+++ b/internal/action/outputs_test.go
@@ -35,12 +35,12 @@ func TestOutputsFromInputs(t *testing.T) {
 		{
 			message: "default inputs",
 			input: Config{
-				Names: []string{"staging", "production"},
-				Tags: map[string][]string{
+				Environments: []string{"staging", "production"},
+				EnvironmentsTags: map[string][]string{
 					"staging":    {"environment:staging"},
 					"production": {"environment:production"},
 				},
-				Variables: map[string][]Variable{
+				EnvironmentsVariables: map[string][]Variable{
 					"staging":    {{Key: "environment", Value: "staging", Category: "terraform"}},
 					"production": {{Key: "environment", Value: "production", Category: "terraform"}},
 				},

--- a/main.go
+++ b/main.go
@@ -7,9 +7,9 @@ import (
 
 func main() {
 	if err := action.Run(action.Inputs{
-		Environments: githubactions.GetInput("environments"),
-		Variables:    githubactions.GetInput("environments_variables"),
-		Tags:         githubactions.GetInput("environments_tags"),
+		Environments:          githubactions.GetInput("environments"),
+		EnvironmentsVariables: githubactions.GetInput("environments_variables"),
+		EnvironmentsTags:      githubactions.GetInput("environments_tags"),
 	}, githubactions.New()); err != nil {
 		githubactions.Fatalf("Error: %s", err)
 	}


### PR DESCRIPTION
Updates `Config` and `Inputs` structs to use `Environments` attribute prefixes to make room for incoming `Tags` which apply to all workspaces. 

The important changes here are the [updates to the Config struct](https://github.com/TakeScoop/terraform-cloud-workspace-inputs-action/compare/rw-prefix-attributes?expand=1#diff-159893f6d6c9b5099b70f154413b0013bd4755320fe8d0b42b53c21c07ebc986R14-R18) and the [updates to the Inputs struct](https://github.com/TakeScoop/terraform-cloud-workspace-inputs-action/compare/rw-prefix-attributes?expand=1#diff-ecff92f29488498fb97fadd50b1ba26efd49f682c70f41787b3e0c896cf927cfR9-R13). The rest is updating the attributes.