### PR TITLE
Refactor tags logic out of inputs, config and outputs

### DIFF
--- a/internal/action/config_test.go
+++ b/internal/action/config_test.go
@@ -15,33 +15,6 @@ type testCaseExtendConfig struct {
 func TestExtendConfig(t *testing.T) {
 	testCases := []testCaseExtendConfig{
 		{
-			message: "no tags",
-			input: [2]Config{
-				{Environments: Environments{"staging"}},
-				{},
-			},
-			expected: Config{
-				Environments:          Environments{"staging"},
-				EnvironmentsTags:      map[string][]string{"staging": {}},
-				EnvironmentsVariables: map[string][]Variable{"staging": {}},
-			},
-		},
-		{
-			message: "dedupe workspace tags",
-			input: [2]Config{
-				{
-					Environments:     Environments{"staging"},
-					EnvironmentsTags: map[string][]string{"staging": {"environment:staging"}},
-				},
-				{EnvironmentsTags: map[string][]string{"staging": {"environment:staging"}}},
-			},
-			expected: Config{
-				Environments:          Environments{"staging"},
-				EnvironmentsTags:      map[string][]string{"staging": {"environment:staging"}},
-				EnvironmentsVariables: map[string][]Variable{"staging": {}},
-			},
-		},
-		{
 			message: "dedupe variables",
 			input: [2]Config{
 				{
@@ -58,7 +31,7 @@ func TestExtendConfig(t *testing.T) {
 			},
 			expected: Config{
 				Environments:     Environments{"staging"},
-				EnvironmentsTags: map[string][]string{"staging": {}},
+				EnvironmentsTags: EnvironmentsTags{"staging": {}},
 				EnvironmentsVariables: map[string][]Variable{
 					"staging": {{Key: "environment", Value: "staging", Category: "terraform"}},
 				},
@@ -77,7 +50,7 @@ func TestExtendConfig(t *testing.T) {
 							{Key: "environment", Value: "production", Category: "terraform"},
 						},
 					},
-					EnvironmentsTags: map[string][]string{
+					EnvironmentsTags: EnvironmentsTags{
 						"staging":    {"environment:staging"},
 						"production": {"environment:production"},
 					},
@@ -93,7 +66,7 @@ func TestExtendConfig(t *testing.T) {
 							{Key: "baz", Value: "woz", Category: "terraform"},
 						},
 					},
-					EnvironmentsTags: map[string][]string{
+					EnvironmentsTags: EnvironmentsTags{
 						"staging":    {"foo:bar"},
 						"production": {"environment:production", "baz:woz"},
 					},
@@ -111,7 +84,7 @@ func TestExtendConfig(t *testing.T) {
 						{Key: "baz", Value: "woz", Category: "terraform"},
 					},
 				},
-				EnvironmentsTags: map[string][]string{
+				EnvironmentsTags: EnvironmentsTags{
 					"staging":    {"environment:staging", "foo:bar"},
 					"production": {"environment:production", "baz:woz"},
 				},
@@ -124,36 +97,6 @@ func TestExtendConfig(t *testing.T) {
 				{Name: "b"},
 			},
 			expected: Config{Name: "a"},
-		},
-		{
-			message: "add tags to empty config",
-			input: [2]Config{
-				{},
-				{Tags: []string{"foo:bar"}},
-			},
-			expected: Config{
-				Tags: []string{"foo:bar"},
-			},
-		},
-		{
-			message: "dedupe tags from same config",
-			input: [2]Config{
-				{},
-				{Tags: []string{"foo:bar", "foo:bar"}},
-			},
-			expected: Config{
-				Tags: []string{"foo:bar"},
-			},
-		},
-		{
-			message: "dedupe tags from different configs",
-			input: [2]Config{
-				{Tags: []string{"foo:bar"}},
-				{Tags: []string{"foo:bar"}},
-			},
-			expected: Config{
-				Tags: []string{"foo:bar"},
-			},
 		},
 	}
 

--- a/internal/action/defaults.go
+++ b/internal/action/defaults.go
@@ -7,7 +7,7 @@ func NewDefaults(environments Environments, name string) Config {
 
 	for _, e := range environments {
 		defaults.Environments = append(defaults.Environments, e)
-		defaults.EnvironmentsTags[e] = []string{fmt.Sprintf("environment:%s", e)}
+		defaults.EnvironmentsTags[e] = Tags{fmt.Sprintf("environment:%s", e)}
 		defaults.EnvironmentsVariables[e] = []Variable{{Key: "environment", Value: e, Category: "terraform"}}
 	}
 

--- a/internal/action/defaults_test.go
+++ b/internal/action/defaults_test.go
@@ -16,21 +16,21 @@ func TestNewDefaults(t *testing.T) {
 	testCases := []testCaseNewDefaults{
 		{
 			message: "empty environments",
-			input:   NewDefaults([]string{}, "empty"),
+			input:   NewDefaults(Environments{}, "empty"),
 			expected: Config{
 				Environments:          Environments{},
-				EnvironmentsTags:      map[string][]string{},
+				EnvironmentsTags:      EnvironmentsTags{},
 				EnvironmentsVariables: map[string][]Variable{},
-				Tags:                  []string{"service:empty"},
+				Tags:                  Tags{"service:empty"},
 				Name:                  "empty",
 			},
 		},
 		{
 			message: "environments",
-			input:   NewDefaults([]string{"staging", "production"}, "name"),
+			input:   NewDefaults(Environments{"staging", "production"}, "name"),
 			expected: Config{
 				Environments: Environments{"staging", "production"},
-				EnvironmentsTags: map[string][]string{
+				EnvironmentsTags: EnvironmentsTags{
 					"staging":    {"environment:staging"},
 					"production": {"environment:production"},
 				},
@@ -38,7 +38,7 @@ func TestNewDefaults(t *testing.T) {
 					"staging":    {{Key: "environment", Value: "staging", Category: "terraform"}},
 					"production": {{Key: "environment", Value: "production", Category: "terraform"}},
 				},
-				Tags: []string{"service:name"},
+				Tags: Tags{"service:name"},
 				Name: "name",
 			},
 		},

--- a/internal/action/inputs.go
+++ b/internal/action/inputs.go
@@ -47,26 +47,14 @@ func (i Inputs) Parse() (Config, error) {
 		}
 	}
 
-	var wsTags map[string][]string
-	if err := yaml.Unmarshal([]byte(i.EnvironmentsTags), &wsTags); err != nil {
-		return Config{}, fmt.Errorf("failed to parse workspace tags: %w", err)
+	wsTags, err := ParseEnvironmentsTags(i.EnvironmentsTags, environments)
+	if err != nil {
+		return Config{}, err
 	}
 
-	for env := range wsTags {
-		found := false
-		for _, e := range environments {
-			if e == env {
-				found = true
-			}
-		}
-		if !found {
-			return Config{}, fmt.Errorf("environment %s in passed variables not found in environments %v: %w", env, environments, ErrEnvironmentNotFound)
-		}
-	}
-
-	var tags []string
-	if err := yaml.Unmarshal([]byte(i.Tags), &tags); err != nil {
-		return Config{}, fmt.Errorf("failed to parse tags: %w", err)
+	tags, err := ParseTags(i.Tags)
+	if err != nil {
+		return Config{}, err
 	}
 
 	return Config{

--- a/internal/action/inputs_test.go
+++ b/internal/action/inputs_test.go
@@ -27,59 +27,6 @@ func TestInputsParse(t *testing.T) {
 			expected: Config{Name: "empty"},
 		},
 		{
-			message: "basic workspace tags",
-			input: Inputs{
-				Name: "workspace",
-				EnvironmentsTags: `---
-staging:
-  - foo:bar
-production:
-  - baz:woz`,
-				Environments: `---
-  - staging
-  - production`,
-			},
-			expected: Config{
-				Name:         "workspace",
-				Environments: Environments{"staging", "production"},
-				EnvironmentsTags: map[string][]string{
-					"staging":    {"foo:bar"},
-					"production": {"baz:woz"},
-				},
-			},
-		},
-		{
-			message: "tags for one environment",
-			input: Inputs{
-				Name: "workspace",
-				Environments: `---
-  - staging
-  - production`,
-				EnvironmentsTags: `---
-staging:
-  - foo:bar`,
-			},
-			expected: Config{
-				Name:         "workspace",
-				Environments: Environments{"staging", "production"},
-				EnvironmentsTags: map[string][]string{
-					"staging": {"foo:bar"},
-				},
-			},
-		},
-		{
-			message: "tags non existent environment",
-			input: Inputs{
-				Name: "workspace",
-				Environments: `---
-- production`,
-				EnvironmentsTags: `---
-staging:
-  - foo:bar`,
-			},
-			err: ErrEnvironmentNotFound,
-		},
-		{
 			message: "basic variables",
 			input: Inputs{
 				Name: "workspace",
@@ -144,19 +91,6 @@ staging:
 			message:  "workspace name",
 			input:    Inputs{Name: "foo"},
 			expected: Config{Name: "foo"},
-		},
-		{
-			message: "tags",
-			input: Inputs{
-				Name: "workspace",
-				Tags: `---
-- department:engineering
-- division:platform`,
-			},
-			expected: Config{
-				Name: "workspace",
-				Tags: []string{"department:engineering", "division:platform"},
-			},
 		},
 	}
 

--- a/internal/action/outputs.go
+++ b/internal/action/outputs.go
@@ -6,12 +6,16 @@ import (
 )
 
 func (c Config) SetOutputs(o Outputter) error {
-	if err := setJSONOutput(o, "workspaces", c.Environments); err != nil {
-		return err
+	if err := c.Environments.SetOutputs(o); err != nil {
+		return fmt.Errorf("failed to set environments output: %w", err)
 	}
 
-	if err := setJSONOutput(o, "workspace_tags", c.EnvironmentsTags); err != nil {
-		return err
+	if err := c.EnvironmentsTags.SetOutputs(o); err != nil {
+		return fmt.Errorf("failed to set environment tags output: %w", err)
+	}
+
+	if err := c.Tags.SetOutputs(o); err != nil {
+		return fmt.Errorf("failed to set tags output: %w", err)
 	}
 
 	for _, vars := range c.EnvironmentsVariables {
@@ -27,10 +31,6 @@ func (c Config) SetOutputs(o Outputter) error {
 	}
 
 	o.SetOutput("name", c.Name)
-
-	if err := setJSONOutput(o, "tags", c.Tags); err != nil {
-		return err
-	}
 
 	return nil
 }

--- a/internal/action/outputs_test.go
+++ b/internal/action/outputs_test.go
@@ -38,7 +38,7 @@ func TestOutputsFromInputs(t *testing.T) {
 			message: "default inputs",
 			input: Config{
 				Environments: Environments{"staging", "production"},
-				EnvironmentsTags: map[string][]string{
+				EnvironmentsTags: EnvironmentsTags{
 					"staging":    {"environment:staging"},
 					"production": {"environment:production"},
 				},
@@ -46,7 +46,7 @@ func TestOutputsFromInputs(t *testing.T) {
 					"staging":    {{Key: "environment", Value: "staging", Category: "terraform"}},
 					"production": {{Key: "environment", Value: "production", Category: "terraform"}},
 				},
-				Tags: []string{"service:workspace"},
+				Tags: Tags{"service:workspace"},
 				Name: "workspace",
 			},
 			expected: testSetOutputsExpected{

--- a/internal/action/tags.go
+++ b/internal/action/tags.go
@@ -1,0 +1,113 @@
+package action
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Tags are workspace tags applied to all workspaces
+type Tags []string
+
+// EnvironmentsTags is a map of environment names to a list of tags applied to that environment's workspace
+type EnvironmentsTags map[string][]string
+
+// ParseTags parses the passed string into universal tags applied to all workspaces
+func ParseTags(s string) (Tags, error) {
+	var tags Tags
+
+	if err := yaml.Unmarshal([]byte(s), &tags); err != nil {
+		return Tags{}, fmt.Errorf("failed to parse tags: %w", err)
+	}
+
+	return tags, nil
+}
+
+// ParseEnvironmentsTags parses a string into a map of environments to workspace tags for that environment
+func ParseEnvironmentsTags(s string, envs Environments) (EnvironmentsTags, error) {
+	var wsTags EnvironmentsTags
+
+	if err := yaml.Unmarshal([]byte(s), &wsTags); err != nil {
+		return EnvironmentsTags{}, fmt.Errorf("failed to parse workspace tags: %w", err)
+	}
+
+	eMap := map[string]bool{}
+	for _, e := range envs {
+		eMap[e] = true
+	}
+
+	for env := range wsTags {
+		if _, ok := eMap[env]; !ok {
+			return EnvironmentsTags{}, fmt.Errorf("environment %s in passed variables not found in environments %v: %w", env, envs, ErrEnvironmentNotFound)
+		}
+	}
+
+	return wsTags, nil
+}
+
+// MergeTags takes two Tags structs and merges them, removing duplicates
+func MergeTags(a Tags, b Tags) Tags {
+	out := Tags{}
+
+	tMap := map[string]bool{}
+
+	for _, t := range append(a, b...) {
+		if _, ok := tMap[t]; !ok {
+			tMap[t] = true
+			out = append(out, t)
+		}
+	}
+
+	return out
+}
+
+func (et EnvironmentsTags) environments() Environments {
+	envs := Environments{}
+
+	for e := range et {
+		envs = append(envs, e)
+	}
+
+	return envs
+}
+
+// MergeEnvironmentsTags takes two EnvironmentsTags structs and merges them, removing duplicates
+func MergeEnvironmentsTags(a EnvironmentsTags, b EnvironmentsTags) EnvironmentsTags {
+	out := EnvironmentsTags{}
+
+	envs := MergeEnvironments(a.environments(), b.environments())
+
+	for _, e := range envs {
+		out[e] = Tags{}
+
+		tagMap := map[string]bool{}
+
+		if aTags, ok := a[e]; ok {
+			for _, t := range aTags {
+				if _, ok := tagMap[t]; !ok {
+					out[e] = append(out[e], t)
+					tagMap[t] = true
+				}
+			}
+		}
+
+		if bTags, ok := b[e]; ok {
+			for _, t := range bTags {
+				if _, ok := tagMap[t]; !ok {
+					out[e] = append(out[e], t)
+					tagMap[t] = true
+				}
+			}
+		}
+	}
+
+	return out
+}
+
+func (t Tags) SetOutputs(o Outputter) error {
+	return setJSONOutput(o, "tags", t)
+}
+
+func (et EnvironmentsTags) SetOutputs(o Outputter) error {
+	return setJSONOutput(o, "workspace_tags", et)
+}

--- a/internal/action/tags_test.go
+++ b/internal/action/tags_test.go
@@ -1,0 +1,312 @@
+package action
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testCaseMergeTags struct {
+	message  string
+	expected Tags
+	input    [2]Tags
+}
+
+func TestMergeTags(t *testing.T) {
+	testCases := []testCaseMergeTags{
+		{
+			message:  "empty",
+			input:    [2]Tags{},
+			expected: Tags{},
+		},
+		{
+			message: "dedupe",
+			input: [2]Tags{
+				{"foo:bar", "environment:staging"},
+				{"environment:staging"},
+			},
+			expected: Tags{"foo:bar", "environment:staging"},
+		},
+		{
+			message: "add",
+			input: [2]Tags{
+				{"environment:staging"},
+				{"environment:staging", "foo:bar"},
+			},
+			expected: Tags{"foo:bar", "environment:staging"},
+		},
+		{
+			message: "add empty",
+			input: [2]Tags{
+				{"environment:staging"},
+				{},
+			},
+			expected: Tags{"environment:staging"},
+		},
+		{
+			message: "add to empty",
+			input: [2]Tags{
+				{},
+				{"environment:staging"},
+			},
+			expected: Tags{"environment:staging"},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.message, func(t *testing.T) {
+			t.Parallel()
+
+			assert.ElementsMatch(t, tc.expected, MergeTags(tc.input[0], tc.input[1]))
+		})
+	}
+}
+
+type testCaseMergeEnvironmentsTags struct {
+	message  string
+	expected EnvironmentsTags
+	input    [2]EnvironmentsTags
+}
+
+func TestMergeEnvironmentsTags(t *testing.T) {
+	testCases := []testCaseMergeEnvironmentsTags{
+		{
+			message:  "empty",
+			input:    [2]EnvironmentsTags{},
+			expected: EnvironmentsTags{},
+		},
+		{
+			message: "dedupe",
+			input: [2]EnvironmentsTags{
+				{"staging": Tags{"foo", "bar"}},
+				{"staging": Tags{"foo"}},
+			},
+			expected: EnvironmentsTags{"staging": Tags{"foo", "bar"}},
+		},
+		{
+			message: "add",
+			input: [2]EnvironmentsTags{
+				{
+					"staging":    Tags{"foo"},
+					"production": Tags{"bar"},
+				},
+				{
+					"staging":    Tags{"environment:staging"},
+					"production": Tags{"environment:production"},
+				},
+			},
+			expected: EnvironmentsTags{
+				"staging":    Tags{"foo", "environment:staging"},
+				"production": Tags{"bar", "environment:production"},
+			},
+		},
+		{
+			message: "add empty",
+			input: [2]EnvironmentsTags{
+				{"staging": Tags{"foo"}},
+				{"staging": Tags{}},
+			},
+			expected: EnvironmentsTags{"staging": Tags{"foo"}},
+		},
+		{
+			message: "add from empty",
+			input: [2]EnvironmentsTags{
+				{"staging": Tags{}},
+				{"staging": Tags{"foo"}},
+			},
+			expected: EnvironmentsTags{"staging": Tags{"foo"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.message, func(t *testing.T) {
+			t.Parallel()
+
+			actual := MergeEnvironmentsTags(tc.input[0], tc.input[1])
+
+			for e, tags := range tc.expected {
+				assert.ElementsMatch(t, tags, actual[e])
+			}
+		})
+	}
+}
+
+type testCaseParseTags struct {
+	message  string
+	input    string
+	expected Tags
+}
+
+func TestParseTags(t *testing.T) {
+	testCases := []testCaseParseTags{
+		{
+			message:  "empty",
+			input:    "",
+			expected: Tags{},
+		},
+		{
+			message: "list of tags",
+			input: `---
+- foo:bar
+- baz:woz
+`,
+			expected: Tags{"foo:bar", "baz:woz"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.message, func(t *testing.T) {
+			t.Parallel()
+
+			tags, err := ParseTags(tc.input)
+			require.NoError(t, err)
+
+			assert.ElementsMatch(t, tc.expected, tags)
+		})
+	}
+}
+
+type testCaseParseEnvironmentsTags struct {
+	message  string
+	input    testCaseParseEnvironmentsTagsInput
+	expected EnvironmentsTags
+	err      error
+}
+
+type testCaseParseEnvironmentsTagsInput struct {
+	value string
+	envs  Environments
+}
+
+func TestParseEnvironmentsTags(t *testing.T) {
+	testCases := []testCaseParseEnvironmentsTags{
+		{
+			message: "empty",
+			input: testCaseParseEnvironmentsTagsInput{
+				value: "",
+				envs:  Environments{},
+			},
+			expected: EnvironmentsTags{},
+		},
+		{
+			message: "map of tags",
+			input: testCaseParseEnvironmentsTagsInput{
+				value: `---
+staging:
+- foo:bar
+- baz:woz
+production:
+- environment:production
+`,
+				envs: Environments{"staging"},
+			},
+			expected: EnvironmentsTags{
+				"staging":    {"foo:bar", "baz:woz"},
+				"production": {"environment:production"},
+			},
+		},
+		{
+			message: "should error if tag parsed for non existent environment",
+			input: testCaseParseEnvironmentsTagsInput{
+				value: `---
+staging:
+- foo:bar
+production:
+- baz:woz
+`,
+				envs: Environments{"staging"},
+			},
+			err: ErrEnvironmentNotFound,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.message, func(t *testing.T) {
+			t.Parallel()
+
+			tags, err := ParseEnvironmentsTags(tc.input.value, tc.input.envs)
+			if tc.err != nil {
+				assert.ErrorIs(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+
+				for env, expected := range tc.expected {
+					assert.ElementsMatch(t, expected, tags[env])
+				}
+			}
+		})
+	}
+}
+
+type testCaseTagsSetOutput struct {
+	message  string
+	input    Tags
+	expected string
+}
+
+func TestTagsSetOutput(t *testing.T) {
+	testCases := []testCaseTagsSetOutput{
+		{
+			message:  "empty",
+			input:    Tags{},
+			expected: `[]`,
+		},
+		{
+			message:  "with tags",
+			input:    Tags{"service:name"},
+			expected: `["service:name"]`,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.message, func(t *testing.T) {
+			t.Parallel()
+			out := newTestOutputter()
+			require.NoError(t, tc.input.SetOutputs(&out))
+			assert.JSONEq(t, tc.expected, out.outputs["tags"])
+		})
+	}
+}
+
+type testCaseEnvironmentsTagsSetOutput struct {
+	message  string
+	input    EnvironmentsTags
+	expected string
+}
+
+func TestEnvironmentsTagsSetOutput(t *testing.T) {
+	testCases := []testCaseEnvironmentsTagsSetOutput{
+		{
+			message:  "empty",
+			input:    EnvironmentsTags{},
+			expected: `{}`,
+		},
+		{
+			message: "with tags",
+			input: EnvironmentsTags{
+				"staging":    Tags{"environment:staging"},
+				"production": Tags{"environment:production"},
+			},
+			expected: `{
+				"staging": ["environment:staging"],
+				"production": ["environment:production"]
+			}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.message, func(t *testing.T) {
+			t.Parallel()
+			out := newTestOutputter()
+			require.NoError(t, tc.input.SetOutputs(&out))
+			assert.JSONEq(t, tc.expected, out.outputs["workspace_tags"])
+		})
+	}
+}


### PR DESCRIPTION
Similar to https://github.com/TakeScoop/terraform-cloud-workspace-inputs-action/pull/9, but for the EnvironmentsTags and Tags inputs. As a reassurance, the end to end tests have not been modified to ensure behavior has not changed. 

Moves the logic for tags into `tags.go`, moves the tests for the logic into `tags_test.go`.